### PR TITLE
[FIX] increase max query length

### DIFF
--- a/config/Migrations/20231113212113_IncreaseMaxQueryLen.php
+++ b/config/Migrations/20231113212113_IncreaseMaxQueryLen.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+class IncreaseMaxQueryLen extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     * @return void
+     */
+    public function change(): void
+    {
+        $table = $this->table('queries');
+        $table->changeColumn('my_query', 'text', [
+            'default' => null,
+            'limit' => MysqlAdapter::TEXT_MEDIUM,
+            'null' => true,
+        ]);
+        $table->update();
+    }
+}


### PR DESCRIPTION
The query definition of complex queries exceeds 65k chars.